### PR TITLE
fix: Ensure Safari compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="no-js">
 
   <header>
     <nav>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+document.documentElement.classList.remove('no-js');
+
 document.addEventListener('DOMContentLoaded', () => {
   fetch('data.json')
     .then(response => response.json())

--- a/style.css
+++ b/style.css
@@ -29,6 +29,12 @@ section.visible {
   transform: translateY(0);
 }
 
+/* Fallback for no-JS */
+.no-js section {
+    opacity: 1;
+    transform: none;
+}
+
 section:last-of-type {
   border-bottom: none;
 }
@@ -80,7 +86,7 @@ h2 {
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  margin: -0.5rem; /* Counteract the margin on li elements */
 }
 
 .skills-list li {
@@ -88,6 +94,7 @@ h2 {
   padding: 10px 20px;
   border-radius: 20px;
   font-weight: bold;
+  margin: 0.5rem; /* Replaces gap for Safari compatibility */
 }
 
 /* Experience & Education */


### PR DESCRIPTION
- Replace Flexbox `gap` with `margin` in `style.css` for the skills list to support older Safari versions.
- Implement a `no-js` fallback class to ensure content is visible by default if JavaScript is disabled or fails to run.
- This improves cross-browser compatibility and ensures the site is functional on Safari.